### PR TITLE
Fix babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,12 @@
 {
+  "presets": [
+    "babel-preset-preact"
+  ],
   "env": {
     "test": {
       "presets": [
         ["preact-cli/babel", { "modules": "commonjs" }]
       ]
-    },
-"lingui": {
-			"presets": ["@babel/preset-env", "@babel/preset-react"]
-		}
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "build/*"
   ],
   "devDependencies": {
-    "@babel/core": "^7.1.2",
     "@lingui/cli": "^2.7.0",
     "@lingui/macro": "^2.7.0",
-    "babel-core": "^7.0.0-bridge.0",
+    "babel-core": "^6.26.3",
     "babel-plugin-macros": "^2.4.2",
+    "babel-preset-preact": "^1.1.0",
     "eslint": "^4.9.0",
     "eslint-config-synacor": "^2.0.2",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
Removed any references to Babel 7, because `preact-cli/babel` preset uses Babel 6.

`yarn start` and `yarn lingui extract` works.

Please follow the docs to setup the rest of the project:
- [Setup](https://lingui.js.org/tutorials/setup-react.html)
- [Tutorial](https://lingui.js.org/tutorials/react.html)
- [Dynamic loading messages](https://lingui.js.org/guides/dynamic-loading-catalogs.html)